### PR TITLE
fix bug https://github.com/rachpt/lanzou-gui/issues/21

### DIFF
--- a/lanzou/api/core.py
+++ b/lanzou/api/core.py
@@ -292,7 +292,8 @@ class LanZouCloud(object):
         html = self._get(self._mydisk_url, params=para)
         if not html:
             return folder_list
-        info = re.findall(r'&nbsp;(.+?)</a>&nbsp;.+"folk(\d+)"(.*?)>.+#BBBBBB">\[?(.*?)\.*\]?</font>', html.text)
+        comp = re.compile(r'&nbsp;([^\n]+?)</a>&nbsp;[^\n]+"folk(\d+)"([^\n]*?)>[^\n]+#BBBBBB">\[?(.*?)?\]?</font>', re.DOTALL)
+        info = comp.findall(html.text)
         for folder_name, fid, pwd_flag, desc in info:
             folder_list.append(Folder(
                 id=int(fid),


### PR DESCRIPTION
修复 因文件夹描述包含`回车符` 而导致的文件夹不显示的bug

https://github.com/rachpt/lanzou-gui/issues/21