### PR TITLE
 修复域名变更链接判断失效

### DIFF
--- a/lanzou/api/utils.py
+++ b/lanzou/api/utils.py
@@ -74,8 +74,8 @@ def is_name_valid(filename: str) -> bool:
 
 def is_file_url(share_url: str) -> bool:
     """判断是否为文件的分享链接"""
-    base_pat = r'https?://.+?\.lanzous.com/.+'
-    user_pat = r'https?://.+?\.lanzous.com/i[a-z0-9]{5,}/?'  # 普通用户 URL 规则
+    base_pat = r'https?://.+?\.lanzou[six].com/.+'
+    user_pat = r'https?://.+?\.lanzou[six].com/i[a-z0-9]{5,}/?'  # 普通用户 URL 规则
     if not re.fullmatch(base_pat, share_url):
         return False
     elif re.fullmatch(user_pat, share_url):
@@ -91,8 +91,8 @@ def is_file_url(share_url: str) -> bool:
 
 def is_folder_url(share_url: str) -> bool:
     """判断是否为文件夹的分享链接"""
-    base_pat = r'https?://.+?\.lanzous.com/.+'
-    user_pat = r'https?://.+?\.lanzous.com/b[a-z0-9]{7,}/?'
+    base_pat = r'https?://.+?\.lanzou[six].com/.+'
+    user_pat = r'https?://.+?\.lanzou[six].com/b[a-z0-9]{7,}/?'
     if not re.fullmatch(base_pat, share_url):
         return False
     elif re.fullmatch(user_pat, share_url):


### PR DESCRIPTION
从 `a-z` ping了一下，发现 `i s x` 结尾的都是蓝奏的域名