### PR TITLE
增加域名fallback，以应对蓝奏云某些域名有时候会短暂挂掉的情况

### DIFF
--- a/lanzou/api/core.py
+++ b/lanzou/api/core.py
@@ -92,11 +92,11 @@ class LanZouCloud(object):
             # 目前网盘默认分享链接是这个，后面可以根据经验，哪个最靠谱，调整先后顺序
             lanzouyun_url.replace(old_domain, 'wwx.lanzoui'),
 
-            lanzouyun_url.replace(old_domain, 'pan.lanzous'),
-            lanzouyun_url.replace(old_domain, 'up.lanzous'),
-            lanzouyun_url.replace(old_domain, 'wws.lanzous'),
-            lanzouyun_url.replace(old_domain, 'www.lanzous'),
-            lanzouyun_url.replace(old_domain, 'wwx.lanzous'),
+            # 本地测试当前可用的域名，后续可以调整
+            lanzouyun_url.replace(old_domain, 'pan.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'up.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'wws.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'www.lanzoui'),
 
             lanzouyun_url.replace(old_domain, 'pan.lanzoux'),
             lanzouyun_url.replace(old_domain, 'up.lanzoux'),
@@ -104,10 +104,13 @@ class LanZouCloud(object):
             lanzouyun_url.replace(old_domain, 'www.lanzoux'),
             lanzouyun_url.replace(old_domain, 'wwx.lanzoux'),
 
-            lanzouyun_url.replace(old_domain, 'pan.lanzoui'),
-            lanzouyun_url.replace(old_domain, 'up.lanzoui'),
-            lanzouyun_url.replace(old_domain, 'wws.lanzoui'),
-            lanzouyun_url.replace(old_domain, 'www.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'wwx.lanzous'),
+
+            # 其余备用的域名，测试时暂时不可用
+            lanzouyun_url.replace(old_domain, 'pan.lanzous'),
+            lanzouyun_url.replace(old_domain, 'up.lanzous'),
+            lanzouyun_url.replace(old_domain, 'wws.lanzous'),
+            lanzouyun_url.replace(old_domain, 'www.lanzous'),
         ]
 
     def ignore_limits(self):

--- a/lanzou/api/core.py
+++ b/lanzou/api/core.py
@@ -79,25 +79,18 @@ class LanZouCloud(object):
 
         return None
 
-    def all_possiable_urls(self, lanzouyun_url:str)-> List[str]:
+    def all_possiable_urls(self, lanzouyun_url: str) -> List[str]:
         if self._host_url not in lanzouyun_url:
             return [lanzouyun_url]
 
         old_domain = 'pan.lanzous'
-        return [
-            lanzouyun_url,
 
-            lanzouyun_url.replace(old_domain, 'pan.lanzoux'),
-            lanzouyun_url.replace(old_domain, 'wws.lanzoux'),
-            lanzouyun_url.replace(old_domain, 'www.lanzoux'),
-            lanzouyun_url.replace(old_domain, 'wwx.lanzoux'),
-
-            lanzouyun_url.replace(old_domain, 'wws.lanzous'),
-            lanzouyun_url.replace(old_domain, 'www.lanzous'),
-            lanzouyun_url.replace(old_domain, 'wwx.lanzous'),
-
-            lanzouyun_url.replace(old_domain, 'up.lanzoui'),
-        ]
+        domains = [lanzouyun_url]
+        for sub_domain in ['pan', 'up', 'wws', 'www', 'wwx']:
+            for main_domain in ['lanzoux', 'lanzous', 'lanzouxi']:
+                new_url = lanzouyun_url.replace(old_domain, f'{sub_domain}.{main_domain}')
+                domains.append(new_url)
+        return domains
 
     def ignore_limits(self):
         """解除官方限制"""

--- a/lanzou/api/core.py
+++ b/lanzou/api/core.py
@@ -79,18 +79,33 @@ class LanZouCloud(object):
 
         return None
 
-    def all_possiable_urls(self, lanzouyun_url: str) -> List[str]:
+    def all_possiable_urls(self, lanzouyun_url:str)-> List[str]:
         if self._host_url not in lanzouyun_url:
             return [lanzouyun_url]
 
         old_domain = 'pan.lanzous'
 
-        domains = [lanzouyun_url]
-        for sub_domain in ['pan', 'up', 'wws', 'www', 'wwx']:
-            for main_domain in ['lanzoux', 'lanzous', 'lanzouxi']:
-                new_url = lanzouyun_url.replace(old_domain, f'{sub_domain}.{main_domain}')
-                domains.append(new_url)
-        return domains
+        return [
+            # 目前网盘默认分享链接是这个，后面可以根据哪个最靠谱，调整顺序
+            lanzouyun_url.replace(old_domain, 'wwx.lanzoui'),
+
+            lanzouyun_url.replace(old_domain, 'pan.lanzous'),
+            lanzouyun_url.replace(old_domain, 'up.lanzous'),
+            lanzouyun_url.replace(old_domain, 'wws.lanzous'),
+            lanzouyun_url.replace(old_domain, 'www.lanzous'),
+            lanzouyun_url.replace(old_domain, 'wwx.lanzous'),
+
+            lanzouyun_url.replace(old_domain, 'pan.lanzoux'),
+            lanzouyun_url.replace(old_domain, 'up.lanzoux'),
+            lanzouyun_url.replace(old_domain, 'wws.lanzoux'),
+            lanzouyun_url.replace(old_domain, 'www.lanzoux'),
+            lanzouyun_url.replace(old_domain, 'wwx.lanzoux'),
+
+            lanzouyun_url.replace(old_domain, 'pan.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'up.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'wws.lanzoui'),
+            lanzouyun_url.replace(old_domain, 'www.lanzoui'),
+        ]
 
     def ignore_limits(self):
         """解除官方限制"""

--- a/lanzou/api/core.py
+++ b/lanzou/api/core.py
@@ -86,7 +86,10 @@ class LanZouCloud(object):
         old_domain = 'pan.lanzous'
 
         return [
-            # 目前网盘默认分享链接是这个，后面可以根据哪个最靠谱，调整顺序
+            # 首先尝试传入的url
+            lanzouyun_url,
+
+            # 目前网盘默认分享链接是这个，后面可以根据经验，哪个最靠谱，调整先后顺序
             lanzouyun_url.replace(old_domain, 'wwx.lanzoui'),
 
             lanzouyun_url.replace(old_domain, 'pan.lanzous'),


### PR DESCRIPTION
https://pan.lanzous.com/ 又挂掉了=、=以前也出现过这种问题，加了下兼容措施，在_get和_post中，如果url包含self._host_url，则通过替换生成以下所有域名的链接，依次去尝试，这样即使一个挂掉，可以用其他的来顶替

```python
        old_domain = 'pan.lanzous'
        return [
            lanzouyun_url,

            lanzouyun_url.replace(old_domain, 'pan.lanzoux'),
            lanzouyun_url.replace(old_domain, 'wws.lanzoux'),
            lanzouyun_url.replace(old_domain, 'www.lanzoux'),
            lanzouyun_url.replace(old_domain, 'wwx.lanzoux'),

            lanzouyun_url.replace(old_domain, 'wws.lanzous'),
            lanzouyun_url.replace(old_domain, 'www.lanzous'),
            lanzouyun_url.replace(old_domain, 'wwx.lanzous'),

            lanzouyun_url.replace(old_domain, 'up.lanzoui'),
        ]
```