### PR TITLE
使用通用封装的_get，确保通用参数都生效，如超时，避免卡在这里

### DIFF
--- a/lanzou/api/__init__.py
+++ b/lanzou/api/__init__.py
@@ -1,5 +1,5 @@
 from lanzou.api.core import LanZouCloud
 
-version = '2.6.5'
+version = '2.6.5.1'
 
 __all__ = ['utils', 'types', 'models', 'LanZouCloud', 'version']

--- a/lanzou/api/core.py
+++ b/lanzou/api/core.py
@@ -1082,7 +1082,7 @@ class LanZouCloud(object):
         if is_file_url(share_url):
             return FolderDetail(LanZouCloud.URL_INVALID)
         try:
-            html = requests.get(share_url, headers=self._headers).text
+            html = self._get(share_url, headers=self._headers).text
         except requests.RequestException:
             return FolderDetail(LanZouCloud.NETWORK_ERROR)
         if '文件不存在' in html or '文件取消' in html:


### PR DESCRIPTION
get_folder_info_by_url中直接使用了requests.get，未设置timeout参数，可能导致卡在这里，应改为使用封装好的_get函数，其内部会设置timeout参数

参考信息：https://docs.python-requests.org/en/master/user/quickstart/#timeouts