### PR TITLE
fix: 修复蓝奏云解析文件链接域名变为 lanzouo 后，is_file_url 和 is_folder_url 判定失败的问题

### DIFF
--- a/lanzou/api/utils.py
+++ b/lanzou/api/utils.py
@@ -78,8 +78,8 @@ def is_name_valid(filename: str) -> bool:
 
 def is_file_url(share_url: str) -> bool:
     """判断是否为文件的分享链接"""
-    base_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou[six].com/.+'  # 子域名可个性化设置或者不存在
-    user_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou[six].com/i[a-zA-Z0-9]{5,}/?'  # 普通用户 URL 规则
+    base_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou\w.com/.+'  # 子域名可个性化设置或者不存在
+    user_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou\w.com/i[a-zA-Z0-9]{5,}/?'  # 普通用户 URL 规则
     if not re.fullmatch(base_pat, share_url):
         return False
     elif re.fullmatch(user_pat, share_url):
@@ -95,8 +95,8 @@ def is_file_url(share_url: str) -> bool:
 
 def is_folder_url(share_url: str) -> bool:
     """判断是否为文件夹的分享链接"""
-    base_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou[six].com/.+'
-    user_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou[six].com/(/s/)?b[a-zA-Z0-9]{7,}/?'
+    base_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou\w.com/.+'
+    user_pat = r'https?://[a-zA-Z0-9-]*?\.?lanzou\w.com/(/s/)?b[a-zA-Z0-9]{7,}/?'
     if not re.fullmatch(base_pat, share_url):
         return False
     elif re.fullmatch(user_pat, share_url):


### PR DESCRIPTION
测试用例

```python
from lanzou.api.utils import is_file_url, is_folder_url

#   1. 去下面这个查备案的网址查 鲁ICP备15001327号 ，看看是否有新的域名备案了
#       https://beian.miit.gov.cn/#/Integrated/recordQuery
all_lanzou_domains = [
    'lanzoup.com',  # 2021-12-10 鲁ICP备15001327号-16
    'lanzout.com',  # 2021-12-10 鲁ICP备15001327号-15
    'lanzouy.com',  # 2021-12-10 鲁ICP备15001327号-14
    'lanzoul.com',  # 2021-12-10 鲁ICP备15001327号-13
    'lanzoug.com',  # 2021-12-10 鲁ICP备15001327号-12
    'lanzouv.com',  # 2021-12-10 鲁ICP备15001327号-11
    'lanzouj.com',  # 2021-12-10 鲁ICP备15001327号-10
    'lanzouq.com',  # 2021-12-10 鲁ICP备15001327号-9
    'lanzouo.com',  # 2021-09-15 鲁ICP备15001327号-8
    'lanzouw.com',  # 2021-09-02 鲁ICP备15001327号-7
    'lanzoui.com',  # 2020-06-09 鲁ICP备15001327号-6
    'lanzoux.com',  # 2020-06-09 鲁ICP备15001327号-5
]


def test_is_file_url():
    # 确保每个备案的域名都能正确判定
    for domain in all_lanzou_domains:
        assert is_file_url(f'https://pan.{domain}/i1234abcd')


def test_is_folder_url():
    # 确保每个备案的域名都能正确判定
    for domain in all_lanzou_domains:
        assert is_folder_url(f'https://pan.{domain}/b1234abcd')

```